### PR TITLE
Add React frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Maven
+/target/
+
+# Node
+frontend/node_modules/
+
+# IDE
+.idea/
+*.iml

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,19 @@
+# Veterinary Management System Frontend
+
+This directory contains a small React application that communicates with the Spring Boot backend running on `http://localhost:8080`.
+
+## Development
+
+1. Install dependencies:
+
+```bash
+npm install
+```
+
+2. Start the development server:
+
+```bash
+npm start
+```
+
+The application will be available at `http://localhost:3000` and the API requests are made to `http://localhost:8080`.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "vms-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.2",
+    "axios": "^1.5.0",
+    "@mui/material": "^5.15.0",
+    "@mui/icons-material": "^5.11.0",
+    "@emotion/react": "^11.11.1",
+    "@emotion/styled": "^11.11.0"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test",
+    "eject": "react-scripts eject"
+  }
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Veterinary Management System</title>
+</head>
+<body>
+  <div id="root"></div>
+</body>
+</html>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import { Box } from '@mui/material';
+import Sidebar from './components/Sidebar';
+import Dashboard from './pages/Dashboard';
+import Customers from './pages/Customers';
+import Animals from './pages/Animals';
+import Appointments from './pages/Appointments';
+import Vaccines from './pages/Vaccines';
+
+function App() {
+  return (
+    <Router>
+      <Box sx={{ display: 'flex' }}>
+        <Sidebar />
+        <Box component="main" sx={{ flexGrow: 1, p: 2 }}>
+          <Routes>
+            <Route path="/" element={<Dashboard />} />
+            <Route path="/customers" element={<Customers />} />
+            <Route path="/animals" element={<Animals />} />
+            <Route path="/appointments" element={<Appointments />} />
+            <Route path="/vaccines" element={<Vaccines />} />
+          </Routes>
+        </Box>
+      </Box>
+    </Router>
+  );
+}
+
+export default App;

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,0 +1,7 @@
+import axios from 'axios';
+
+const api = axios.create({
+  baseURL: 'http://localhost:8080/v1'
+});
+
+export default api;

--- a/frontend/src/components/Sidebar.js
+++ b/frontend/src/components/Sidebar.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Drawer, List, ListItem, ListItemText, Toolbar } from '@mui/material';
+import { Link } from 'react-router-dom';
+
+const menuItems = [
+  { text: 'Dashboard', path: '/' },
+  { text: 'Customers', path: '/customers' },
+  { text: 'Animals', path: '/animals' },
+  { text: 'Appointments', path: '/appointments' },
+  { text: 'Vaccines', path: '/vaccines' },
+];
+
+const Sidebar = () => (
+  <Drawer variant="permanent" sx={{ width: 200, [`& .MuiDrawer-paper`]: { width: 200, boxSizing: 'border-box' } }}>
+    <Toolbar />
+    <List>
+      {menuItems.map((item) => (
+        <ListItem button key={item.text} component={Link} to={item.path}>
+          <ListItemText primary={item.text} />
+        </ListItem>
+      ))}
+    </List>
+  </Drawer>
+);
+
+export default Sidebar;

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/src/pages/Animals.js
+++ b/frontend/src/pages/Animals.js
@@ -1,0 +1,93 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Typography,
+  Table,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableBody,
+  TextField,
+  CircularProgress,
+  Dialog,
+  DialogTitle,
+  DialogContent
+} from '@mui/material';
+import api from '../api';
+
+function Animals() {
+  const [animals, setAnimals] = useState([]);
+  const [filter, setFilter] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [selected, setSelected] = useState(null);
+
+  const fetchAnimals = async () => {
+    setLoading(true);
+    try {
+      const url = filter ? `/animals?name=${filter}` : '/animals';
+      const res = await api.get(url);
+      const list = res.data.data ? res.data.data.content : res.data;
+      setAnimals(list);
+    } catch (err) {
+      setError('Failed to load animals');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchAnimals();
+  }, [filter]);
+
+  return (
+    <div>
+      <Typography variant="h4" gutterBottom>
+        Animals
+      </Typography>
+      <TextField label="Filter by name" value={filter} onChange={(e) => setFilter(e.target.value)} sx={{ mb: 2 }} />
+      {loading ? (
+        <CircularProgress />
+      ) : error ? (
+        <Typography color="error">{error}</Typography>
+      ) : (
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell>ID</TableCell>
+              <TableCell>Name</TableCell>
+              <TableCell>Species</TableCell>
+              <TableCell>Breed</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {animals.map((a) => (
+              <TableRow key={a.id} hover onClick={() => setSelected(a)} style={{ cursor: 'pointer' }}>
+                <TableCell>{a.id}</TableCell>
+                <TableCell>{a.name}</TableCell>
+                <TableCell>{a.species}</TableCell>
+                <TableCell>{a.breed}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+
+      <Dialog open={Boolean(selected)} onClose={() => setSelected(null)}>
+        <DialogTitle>Animal Details</DialogTitle>
+        <DialogContent>
+          {selected && (
+            <div>
+              <Typography>Name: {selected.name}</Typography>
+              <Typography>Species: {selected.species}</Typography>
+              <Typography>Breed: {selected.breed}</Typography>
+              <Typography>Gender: {selected.gender}</Typography>
+              <Typography>Color: {selected.colour}</Typography>
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+export default Animals;

--- a/frontend/src/pages/Appointments.js
+++ b/frontend/src/pages/Appointments.js
@@ -1,0 +1,127 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Typography,
+  Table,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableBody,
+  Button,
+  TextField,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  CircularProgress
+} from '@mui/material';
+import api from '../api';
+
+const emptyAppointment = { id: null, appointmentDate: '', doctorId: '', animalId: '' };
+
+function Appointments() {
+  const [appointments, setAppointments] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [open, setOpen] = useState(false);
+  const [formData, setFormData] = useState(emptyAppointment);
+
+  const fetchAppointments = async () => {
+    setLoading(true);
+    try {
+      const res = await api.get('/appointments');
+      const list = res.data.data ? res.data.data.content : res.data;
+      setAppointments(list);
+    } catch (err) {
+      setError('Failed to load appointments');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => { fetchAppointments(); }, []);
+
+  const handleDelete = async (id) => {
+    await api.delete(`/appointments/${id}`);
+    fetchAppointments();
+  };
+
+  const handleOpen = () => {
+    setFormData(emptyAppointment);
+    setOpen(true);
+  };
+  const handleClose = () => setOpen(false);
+
+  const handleSave = async () => {
+    try {
+      await api.post('/appointments', formData);
+      handleClose();
+      fetchAppointments();
+    } catch (err) {
+      setError('Failed to save appointment');
+    }
+  };
+
+  const handleChange = (field) => (e) => {
+    setFormData({ ...formData, [field]: e.target.value });
+  };
+
+  return (
+    <div>
+      <Typography variant="h4" gutterBottom>
+        Appointments
+      </Typography>
+      <Button variant="contained" onClick={handleOpen}>Schedule Appointment</Button>
+      {loading ? (
+        <CircularProgress />
+      ) : error ? (
+        <Typography color="error">{error}</Typography>
+      ) : (
+        <Table sx={{ mt: 2 }}>
+          <TableHead>
+            <TableRow>
+              <TableCell>ID</TableCell>
+              <TableCell>Date</TableCell>
+              <TableCell>Doctor</TableCell>
+              <TableCell>Animal</TableCell>
+              <TableCell>Actions</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {appointments.map((a) => (
+              <TableRow key={a.id}>
+                <TableCell>{a.id}</TableCell>
+                <TableCell>{a.appointmentDate}</TableCell>
+                <TableCell>{a.doctorId}</TableCell>
+                <TableCell>{a.animalId}</TableCell>
+                <TableCell>
+                  <Button color="error" size="small" onClick={() => handleDelete(a.id)}>Delete</Button>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+
+      <Dialog open={open} onClose={handleClose} fullWidth>
+        <DialogTitle>Schedule Appointment</DialogTitle>
+        <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
+          <TextField
+            label="Appointment Date"
+            type="datetime-local"
+            InputLabelProps={{ shrink: true }}
+            value={formData.appointmentDate}
+            onChange={handleChange('appointmentDate')}
+          />
+          <TextField label="Doctor ID" value={formData.doctorId} onChange={handleChange('doctorId')} />
+          <TextField label="Animal ID" value={formData.animalId} onChange={handleChange('animalId')} />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleClose}>Cancel</Button>
+          <Button onClick={handleSave}>Save</Button>
+        </DialogActions>
+      </Dialog>
+    </div>
+  );
+}
+
+export default Appointments;

--- a/frontend/src/pages/Customers.js
+++ b/frontend/src/pages/Customers.js
@@ -1,0 +1,135 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Typography,
+  Table,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableBody,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField
+} from '@mui/material';
+import api from '../api';
+
+const emptyCustomer = { id: null, name: '', phone: '', email: '', city: '', address: '' };
+
+function Customers() {
+  const [customers, setCustomers] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [open, setOpen] = useState(false);
+  const [editData, setEditData] = useState(emptyCustomer);
+
+  const fetchCustomers = async () => {
+    setLoading(true);
+    try {
+      const res = await api.get('/customers');
+      const list = res.data.data ? res.data.data.content : res.data;
+      setCustomers(list);
+    } catch (err) {
+      setError('Failed to load customers');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchCustomers();
+  }, []);
+
+  const handleDelete = async (id) => {
+    await api.delete(`/customers/${id}`);
+    fetchCustomers();
+  };
+
+  const handleOpen = (c = emptyCustomer) => {
+    setEditData(c);
+    setOpen(true);
+  };
+
+  const handleClose = () => setOpen(false);
+
+  const handleSave = async () => {
+    try {
+      if (editData.id) {
+        await api.put(`/customers/${editData.id}`, editData);
+      } else {
+        await api.post('/customers', editData);
+      }
+      handleClose();
+      fetchCustomers();
+    } catch (err) {
+      setError('Failed to save customer');
+    }
+  };
+
+  const handleChange = (field) => (e) => {
+    setEditData({ ...editData, [field]: e.target.value });
+  };
+
+  return (
+    <div>
+      <Typography variant="h4" gutterBottom>
+        Customers
+      </Typography>
+      <Button variant="contained" onClick={() => handleOpen()}>Add Customer</Button>
+      {loading ? (
+        <CircularProgress />
+      ) : error ? (
+        <Typography color="error">{error}</Typography>
+      ) : (
+        <Table sx={{ mt: 2 }}>
+          <TableHead>
+            <TableRow>
+              <TableCell>ID</TableCell>
+              <TableCell>Name</TableCell>
+              <TableCell>Phone</TableCell>
+              <TableCell>Email</TableCell>
+              <TableCell>City</TableCell>
+              <TableCell>Address</TableCell>
+              <TableCell>Actions</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {customers.map((c) => (
+              <TableRow key={c.id}>
+                <TableCell>{c.id}</TableCell>
+                <TableCell>{c.name}</TableCell>
+                <TableCell>{c.phone}</TableCell>
+                <TableCell>{c.email}</TableCell>
+                <TableCell>{c.city}</TableCell>
+                <TableCell>{c.address}</TableCell>
+                <TableCell>
+                  <Button size="small" onClick={() => handleOpen(c)}>Edit</Button>
+                  <Button size="small" color="error" onClick={() => handleDelete(c.id)}>Delete</Button>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+
+      <Dialog open={open} onClose={handleClose} fullWidth>
+        <DialogTitle>{editData.id ? 'Edit Customer' : 'Add Customer'}</DialogTitle>
+        <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
+          <TextField label="Name" value={editData.name} onChange={handleChange('name')} />
+          <TextField label="Phone" value={editData.phone} onChange={handleChange('phone')} />
+          <TextField label="Email" value={editData.email} onChange={handleChange('email')} />
+          <TextField label="City" value={editData.city} onChange={handleChange('city')} />
+          <TextField label="Address" value={editData.address} onChange={handleChange('address')} />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleClose}>Cancel</Button>
+          <Button onClick={handleSave}>Save</Button>
+        </DialogActions>
+      </Dialog>
+    </div>
+  );
+}
+
+export default Customers;

--- a/frontend/src/pages/Dashboard.js
+++ b/frontend/src/pages/Dashboard.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Typography } from '@mui/material';
+
+const Dashboard = () => (
+  <div>
+    <Typography variant="h4" gutterBottom>
+      Veterinary Management System
+    </Typography>
+    <Typography>Welcome to the dashboard.</Typography>
+  </div>
+);
+
+export default Dashboard;

--- a/frontend/src/pages/Vaccines.js
+++ b/frontend/src/pages/Vaccines.js
@@ -1,0 +1,130 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Typography,
+  Table,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableBody,
+  Button,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  CircularProgress
+} from '@mui/material';
+import api from '../api';
+
+const emptyVaccine = { id: null, name: '', code: '', protectionStartDate: '', protectionFinishDate: '', animalId: '' };
+
+function Vaccines() {
+  const [vaccines, setVaccines] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [open, setOpen] = useState(false);
+  const [formData, setFormData] = useState(emptyVaccine);
+
+  const fetchVaccines = async () => {
+    setLoading(true);
+    try {
+      const res = await api.get('/vaccines');
+      const list = res.data.data ? res.data.data.content : res.data;
+      setVaccines(list);
+    } catch (err) {
+      setError('Failed to load vaccines');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => { fetchVaccines(); }, []);
+
+  const handleOpen = () => {
+    setFormData(emptyVaccine);
+    setOpen(true);
+  };
+  const handleClose = () => setOpen(false);
+
+  const handleSave = async () => {
+    try {
+      await api.post('/vaccines', formData);
+      handleClose();
+      fetchVaccines();
+    } catch (err) {
+      setError('Failed to save vaccine');
+    }
+  };
+
+  const handleChange = (field) => (e) => {
+    setFormData({ ...formData, [field]: e.target.value });
+  };
+
+  return (
+    <div>
+      <Typography variant="h4" gutterBottom>
+        Vaccines
+      </Typography>
+      <Button variant="contained" onClick={handleOpen}>Add Vaccine</Button>
+      {loading ? (
+        <CircularProgress />
+      ) : error ? (
+        <Typography color="error">{error}</Typography>
+      ) : (
+        <Table sx={{ mt: 2 }}>
+          <TableHead>
+            <TableRow>
+              <TableCell>ID</TableCell>
+              <TableCell>Name</TableCell>
+              <TableCell>Code</TableCell>
+              <TableCell>Start</TableCell>
+              <TableCell>Finish</TableCell>
+              <TableCell>Animal</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {vaccines.map((v) => (
+              <TableRow key={v.id}>
+                <TableCell>{v.id}</TableCell>
+                <TableCell>{v.name}</TableCell>
+                <TableCell>{v.code}</TableCell>
+                <TableCell>{v.protectionStartDate}</TableCell>
+                <TableCell>{v.protectionFinishDate}</TableCell>
+                <TableCell>{v.animalId}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+
+      <Dialog open={open} onClose={handleClose} fullWidth>
+        <DialogTitle>Add Vaccine</DialogTitle>
+        <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
+          <TextField label="Name" value={formData.name} onChange={handleChange('name')} />
+          <TextField label="Code" value={formData.code} onChange={handleChange('code')} />
+          <TextField
+            label="Protection Start"
+            type="date"
+            InputLabelProps={{ shrink: true }}
+            value={formData.protectionStartDate}
+            onChange={handleChange('protectionStartDate')}
+          />
+          <TextField
+            label="Protection Finish"
+            type="date"
+            InputLabelProps={{ shrink: true }}
+            value={formData.protectionFinishDate}
+            onChange={handleChange('protectionFinishDate')}
+          />
+          <TextField label="Animal ID" value={formData.animalId} onChange={handleChange('animalId')} />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleClose}>Cancel</Button>
+          <Button onClick={handleSave}>Save</Button>
+        </DialogActions>
+      </Dialog>
+    </div>
+  );
+}
+
+export default Vaccines;


### PR DESCRIPTION
## Summary
- create new React frontend in `/frontend`
- add pages for dashboard, customers, animals, appointments and vaccines
- use React Router for navigation and Material UI for layout
- document how to run the frontend
- ignore node modules in git

## Testing
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858505d5f9c833184c452c9a9252cb4